### PR TITLE
Add External Integration System for Third-Party Plugin Support

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -4,7 +4,7 @@ version: 0.3.4
 main: Nicholass003\TopStats\TopStats
 author: nicholass003
 website: https://github.com/nicholass003/TopStats
-softdepend: ["BedrockEconomy", "EconomyAPI"]
+softdepend: ["BedrockEconomy", "EconomyAPI", "TopVoter"]
 permissions:
   topstats.command:
     default: op

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -1,7 +1,7 @@
 # TopStats Configuration #
 # WARNING: Do NOT change the config-version manually!
 # This version is managed by the plugin and changing it may cause issues.
-config-version: "1.0.1"
+config-version: "1.0.2"
 # Supported Databases:
 # - json
 # - mysql
@@ -27,9 +27,19 @@ max-list: 10
 # Time Format:
 # year, month, week, day, hour, minute, second
 time-format: "{year}y {month}m {week}w {day}d {hour}h {minute}m {second}s"
+
+# External Integrations
+# Set external integrations to activate custom data from external plugins
+# Example: `TopVoter` with Custom Data `vote`
+# Supported External Integrations:
+# - TopVoter
+external-integrations:
+  TopVoter: true
+
 # Custom Data
 # Set custom data to initialize Leaderboard type data
 custom-data:
+  - "vote"
   - "exampledata1"
   - "exampledata2"
 # Supported Models:
@@ -144,6 +154,9 @@ models:
     online-time:
       title: "#{rank_online-time} {player}"
       description: "With time {online-time}"
+    vote:
+      title: "#{rank_vote} {player}"
+      description: "With vote {vote}"
     xp:
       title: "#{rank_xp} {player}"
       description: "With xp {xp}"
@@ -215,6 +228,9 @@ models:
     online-time:
       title: ">> TOP ONLINE TIME <<"
       description: "#{rank_online-time} {player} {online-time}{line}"
+    vote:
+      title: ">> TOP VOTE <<"
+      description: "#{rank_vote} {player} {vote}{line}"
     xp:
       title: ">> TOP XP <<"
       description: "#{rank_xp} {player} {xp}{line}"

--- a/src/command/subcommand/create.php
+++ b/src/command/subcommand/create.php
@@ -31,6 +31,7 @@ use Nicholass003\Textify\Lib\Model\Model;
 use Nicholass003\Textify\Lib\Model\Variant;
 use Nicholass003\Textify\Lib\Textify;
 use Nicholass003\TopStats\Database\Data\DataType;
+use Nicholass003\TopStats\External\ExternalIntegrationRegistry;
 use Nicholass003\TopStats\Leaderboard\Leaderboard;
 use Nicholass003\TopStats\Utils\Utils;
 use pocketmine\command\CommandSender;
@@ -38,8 +39,9 @@ use pocketmine\entity\Location;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\player\Player;
 use pocketmine\utils\TextFormat;
-use function array_merge;
+use function array_unique;
 use function in_array;
+use const SORT_STRING;
 
 class CreateSubCommand extends TopStatsSubCommand{
 
@@ -59,7 +61,18 @@ class CreateSubCommand extends TopStatsSubCommand{
 		}
 		if(isset($args["model"])){
 			if(isset($args["type"])){
-				if(!in_array($args["type"], array_merge(DataType::ALL, $this->plugin->getConfig()->get("custom-data", [])), true)){
+				$builtInTypes = DataType::ALL;
+				$customTypes = $this->plugin->getConfig()->get("custom-data", []);
+
+				$externalTypes = ExternalIntegrationRegistry::getInstance()->getActiveTypes();
+
+				$allowedTypes = array_unique([
+					...$builtInTypes,
+					...$customTypes,
+					...$externalTypes
+				], SORT_STRING);
+
+				if(!in_array($args["type"], $allowedTypes, true)){
 					$sender->sendMessage(TextFormat::RED . "Usage: /topstats " . $aliasUsed . " " . $args["model"] . " <type> <top>");
 					$sender->sendMessage(TextFormat::RED . "Type \"/topstats types\" to get type list");
 					return;
@@ -99,14 +112,18 @@ class CreateSubCommand extends TopStatsSubCommand{
 					Textify::TAG_COMPOUND => CompoundTag::create()->setTag(Model::TAG_MODEL, CompoundTag::create()->setString(Leaderboard::TAG_TYPE, $args["type"])->setByte(Leaderboard::TAG_TOP, $args["top"] ?? 0))
 				];
 
+				$source = ExternalIntegrationRegistry::getInstance()->getSource($args["type"]);
+				$entries = $source !== null ? $source->getEntries() : [];
+				$forceSorting = $source !== null ? $source->getIntegration()->isForceSorting() : false;
 				if($variant === Variant::PLAYER){
-					$extraData[Textify::TAG_SKIN] = Utils::getTopStatsPlayerSkin($this->plugin->getDatabase()->getTemporaryData(), $args["type"], (int) $args["top"] ?? 1);
+					$extraData[Textify::TAG_SKIN] = Utils::getTopStatsPlayerSkin(DataType::get($args["type"]) !== false ? $this->plugin->getDatabase()->getTemporaryData() : $entries, $args["type"], (int) $args["top"] ?? 1);
 				}elseif($variant === Variant::TEXT && $center){
 					$location = Location::fromObject($location->add(0, 0.5, 0), $location->getWorld());
 				}
 
 				$leaderboard = new Leaderboard(Textify::create($variant, $location, "", "", null, $extraData));
 				$this->leaderboardManager->add($leaderboard);
+				$leaderboard->setForceSorting($forceSorting);
 				$leaderboard->spawn();
 
 				$sender->sendMessage(TextFormat::GREEN . "Successfully spawn TopStats with model: " . $args["model"] . " type: " . $args["type"]);

--- a/src/command/subcommand/create.php
+++ b/src/command/subcommand/create.php
@@ -62,13 +62,11 @@ class CreateSubCommand extends TopStatsSubCommand{
 		if(isset($args["model"])){
 			if(isset($args["type"])){
 				$builtInTypes = DataType::ALL;
-				$customTypes = $this->plugin->getConfig()->get("custom-data", []);
 
 				$externalTypes = ExternalIntegrationRegistry::getInstance()->getActiveTypes();
 
 				$allowedTypes = array_unique([
 					...$builtInTypes,
-					...$customTypes,
 					...$externalTypes
 				], SORT_STRING);
 

--- a/src/command/subcommand/list.php
+++ b/src/command/subcommand/list.php
@@ -25,7 +25,6 @@ declare(strict_types=1);
 namespace Nicholass003\TopStats\Command\SubCommand;
 
 use Nicholass003\Textify\Lib\Model\Model;
-use Nicholass003\TopStats\Leaderboard\Leaderboard;
 use Nicholass003\TopStats\TopStats;
 use pocketmine\command\CommandSender;
 use pocketmine\utils\TextFormat;
@@ -45,7 +44,7 @@ class ListSubCommand extends TopStatsSubCommand{
 			$sender->sendMessage(TextFormat::YELLOW . "TopStats List:");
 			foreach($leaderboardManager->leaderboards() as $id => $leaderboard){
 				if(!$leaderboard->getModel() instanceof Model) continue;
-				$sender->sendMessage(TextFormat::GREEN . "- ModelID: {$id}, ModelVariant: " . $leaderboard->getModel()->getVariant()->value . ", DataType: " . $leaderboard->getModel()->getCompoundTag()->getString(Leaderboard::TAG_TYPE));
+				$sender->sendMessage(TextFormat::GREEN . "- ModelID: {$id}, ModelVariant: " . $leaderboard->getModel()->getVariant()->value . ", DataType: " . $leaderboard->getType());
 			}
 		}
 	}

--- a/src/command/subcommand/type.php
+++ b/src/command/subcommand/type.php
@@ -25,9 +25,11 @@ declare(strict_types=1);
 namespace Nicholass003\TopStats\Command\SubCommand;
 
 use Nicholass003\TopStats\Database\Data\DataType;
+use Nicholass003\TopStats\External\ExternalIntegrationRegistry;
 use pocketmine\command\CommandSender;
 use pocketmine\utils\TextFormat;
-use function array_merge;
+use function array_unique;
+use const SORT_STRING;
 
 class TypeSubCommand extends TopStatsSubCommand{
 
@@ -37,7 +39,15 @@ class TypeSubCommand extends TopStatsSubCommand{
 
 	public function onRun(CommandSender $sender, string $aliasUsed, array $args) : void{
 		$sender->sendMessage(TextFormat::YELLOW . "TopStats DataType List:");
-		foreach(array_merge(DataType::ALL, $this->plugin->getConfig()->get("custom-data", [])) as $type){
+		$builtInTypes = DataType::ALL;
+
+		$externalTypes = ExternalIntegrationRegistry::getInstance()->getActiveTypes();
+
+		$allowedTypes = array_unique([
+			...$builtInTypes,
+			...$externalTypes
+		], SORT_STRING);
+		foreach($allowedTypes as $type){
 			$sender->sendMessage(TextFormat::GREEN . " - {$type}");
 		}
 	}

--- a/src/database/data/type.php
+++ b/src/database/data/type.php
@@ -79,11 +79,16 @@ final class DataType{
 
 	public static function setup() : void{
 		foreach(self::ALL as $type){
-			self::$types[$type] = str_replace("-", "_", $type);
+			self::$types[$type] = self::reprocess($type);
 		}
 	}
 
 	public static function get(string $type) : false|string{
+		$type = self::reprocess($type);
 		return self::$types[$type] ?? false;
+	}
+
+	private static function reprocess(string $value) : string{
+		return str_replace("-", "_", $value);
 	}
 }

--- a/src/external/external.php
+++ b/src/external/external.php
@@ -1,0 +1,158 @@
+<?php
+
+/*
+ * Copyright (c) 2024 - present nicholass003
+ *        _      _           _                ___   ___ ____
+ *       (_)    | |         | |              / _ \ / _ \___ \
+ *  _ __  _  ___| |__   ___ | | __ _ ___ ___| | | | | | |__) |
+ * | '_ \| |/ __| '_ \ / _ \| |/ _` / __/ __| | | | | | |__ <
+ * | | | | | (__| | | | (_) | | (_| \__ \__ \ |_| | |_| |__) |
+ * |_| |_|_|\___|_| |_|\___/|_|\__,_|___/___/\___/ \___/____/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author  nicholass003
+ * @link    https://github.com/nicholass003/
+ *
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Nicholass003\TopStats\External;
+
+use Nicholass003\TopStats\TopStats;
+use pocketmine\event\Event;
+use pocketmine\event\EventPriority;
+use pocketmine\Server;
+use pocketmine\utils\SingletonTrait;
+use function array_keys;
+
+interface ExternalIntegration extends ExternalTypeNames{
+
+	/**
+	 * Return unique type string (ex: "vote", "kdr", "playtime")
+	 */
+	public function getType() : string;
+
+	/**
+	 * Class of events to be handled
+	 */
+	public function getEventClass() : string;
+
+	/**
+	 * Extract data from event → format:
+	 * [
+	 *   "PlayerA" => value,
+	 *   "PlayerB" => value,
+	 * ]
+	 */
+	public function extractData(object $event) : array;
+
+	/**
+	 * Indicates whether the integration already performs its own sorting
+	 * inside `extractData()`, meaning TopStats should NOT sort the data again.
+	 *
+	 * If this returns **true**, the integration guarantees that the array returned
+	 * by `extractData()` is already properly sorted (usually in descending order),
+	 * and therefore TopStats must use the data as-is without applying any
+	 * additional sorting.
+	 *
+	 * If this returns **false**, TopStats will apply its internal sorting logic
+	 * to the extracted data.
+	 *
+	 * @return bool  True if integration handles sorting; false if TopStats should sort.
+	 */
+	public function isForceSorting() : bool;
+}
+
+class ExternalSource{
+
+	/**
+	 * @param array<string, int|float> $entries
+	 */
+	public function __construct(
+		private string $type,
+		private ExternalIntegration $integration,
+		private array $entries = []
+	){}
+
+	public function getType() : string{
+		return $this->type;
+	}
+
+	public function getIntegration() : ExternalIntegration{
+		return $this->integration;
+	}
+
+	public function getEntries() : array{
+		return $this->entries;
+	}
+
+	public function setEntries(array $entries) : void{
+		$this->entries = $entries;
+	}
+}
+
+final class ExternalIntegrationRegistry{
+	use SingletonTrait;
+
+	/** @var array<string, ExternalSource> */
+	private array $sources = [];
+
+	/** @var array<string, ExternalIntegration> */
+	private array $integrations = [];
+
+	public function register(ExternalIntegration $integration, int $eventPriority = EventPriority::NORMAL) : void{
+		$type = $integration->getType();
+		$eventClass = $integration->getEventClass();
+
+		$this->integrations[$type] = $integration;
+
+		$this->sources[$type] = new ExternalSource($type, $integration);
+
+		Server::getInstance()
+			->getPluginManager()
+			->registerEvent(
+				$eventClass,
+				function(Event $ev) use($type, $integration) : void{
+					$this->handleEvent($type, $integration, $ev);
+				},
+				$eventPriority,
+				TopStats::getInstance()
+			);
+	}
+
+	public function unregister(string $type) : void{
+		unset($this->sources[$type]);
+	}
+
+	private function handleEvent(string $type, ExternalIntegration $integration, Event $ev) : void{
+		$data = $integration->extractData($ev);
+
+		$source = $this->getSource($type);
+		if($source === null){
+			return;
+		}
+
+		$source->setEntries($data);
+
+		TopStats::getInstance()
+			->getLeaderboardManager()
+			->dispatchLeaderboardUpdate($type, $source->getEntries());
+	}
+
+	public function getSource(string $type) : ?ExternalSource{
+		return $this->sources[$type] ?? null;
+	}
+
+	/**
+	 * Return list of active external types (ex: ["vote", "kdr", ...])
+	 */
+	public function getActiveTypes() : array{
+		return array_keys($this->integrations);
+	}
+}

--- a/src/external/support/top_voter.php
+++ b/src/external/support/top_voter.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * Copyright (c) 2024 - present nicholass003
+ *        _      _           _                ___   ___ ____
+ *       (_)    | |         | |              / _ \ / _ \___ \
+ *  _ __  _  ___| |__   ___ | | __ _ ___ ___| | | | | | |__) |
+ * | '_ \| |/ __| '_ \ / _ \| |/ _` / __/ __| | | | | | |__ <
+ * | | | | | (__| | | | (_) | | (_| \__ \__ \ |_| | |_| |__) |
+ * |_| |_|_|\___|_| |_|\___/|_|\__,_|___/___/\___/ \___/____/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author  nicholass003
+ * @link    https://github.com/nicholass003/
+ *
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Nicholass003\TopStats\External\Support;
+
+use Nicholass003\TopStats\External\ExternalIntegration;
+use SalmonDE\TopVoter\Events\DataUpdateEvent;
+
+class TopVoterIntegration implements ExternalIntegration{
+
+	public function getType() : string{
+		return self::TOP_VOTER;
+	}
+
+	public function getEventClass() : string{
+		return DataUpdateEvent::class;
+	}
+
+	public function extractData(object $event) : array{
+		/** @var DataUpdateEvent $event */
+		$rawData = $event->getVoteData();
+
+		$result = [];
+
+		foreach($rawData as $entry){
+			$name = $entry["nickname"];
+			$votes = (int) $entry["votes"];
+
+			$result[$name] = [
+				"name" => $name,
+				$this->getType() => $votes
+			];
+		}
+
+		return $result;
+	}
+
+	public function isForceSorting() : bool{
+		return true;
+	}
+}

--- a/src/external/types.php
+++ b/src/external/types.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * Copyright (c) 2024 - present nicholass003
+ *        _      _           _                ___   ___ ____
+ *       (_)    | |         | |              / _ \ / _ \___ \
+ *  _ __  _  ___| |__   ___ | | __ _ ___ ___| | | | | | |__) |
+ * | '_ \| |/ __| '_ \ / _ \| |/ _` / __/ __| | | | | | |__ <
+ * | | | | | (__| | | | (_) | | (_| \__ \__ \ |_| | |_| |__) |
+ * |_| |_|_|\___|_| |_|\___/|_|\__,_|___/___/\___/ \___/____/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author  nicholass003
+ * @link    https://github.com/nicholass003/
+ *
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Nicholass003\TopStats\External;
+
+interface ExternalTypeNames{
+
+	public const TOP_VOTER = "vote"; //TopVoter by SalmonDE, @link https://github.com/SalmonDE/TopVoter
+}

--- a/src/leaderboard/leaderboard.php
+++ b/src/leaderboard/leaderboard.php
@@ -29,6 +29,7 @@ use Nicholass003\Textify\Lib\Model\Model;
 use Nicholass003\Textify\Lib\Model\NonPlayerCharacter;
 use Nicholass003\TopStats\Database\Data\DataType;
 use Nicholass003\TopStats\Database\IDatabase;
+use Nicholass003\TopStats\External\ExternalIntegrationRegistry;
 use Nicholass003\TopStats\TopStats;
 use Nicholass003\TopStats\Utils\Utils;
 use function count;
@@ -57,13 +58,17 @@ class Leaderboard implements \JsonSerializable{
 		protected Model $model
 	){
 		$this->database = TopStats::getInstance()->getDatabase();
-		$this->text = TopStats::getInstance()->getConfig()->getNested("models." . $model->getVariant()->value . "." . $model->getCompoundTag()->getString(self::TAG_TYPE) . ".description");
-		$this->title = TopStats::getInstance()->getConfig()->getNested("models." . $model->getVariant()->value . "." . $model->getCompoundTag()->getString(self::TAG_TYPE) . ".title");
+		$this->text = TopStats::getInstance()->getConfig()->getNested("models." . $model->getVariant()->value . "." . $this->getType() . ".description");
+		$this->title = TopStats::getInstance()->getConfig()->getNested("models." . $model->getVariant()->value . "." . $this->getType() . ".title");
 		$this->id = Utils::getNextTopStatsIds();
 	}
 
 	public function getId() : int{
 		return $this->id;
+	}
+
+	public function getType() : string{
+		return $this->model->getCompoundTag()->getString(self::TAG_TYPE);
 	}
 
 	public function getModel() : Model{
@@ -88,9 +93,10 @@ class Leaderboard implements \JsonSerializable{
 	}
 
 	public function spawn() : void{
+		$source = ExternalIntegrationRegistry::getInstance()->getSource($this->getType());
 		foreach($this->model->getViewers() as $player){
 			$this->model->send($player, Action::ADD);
-			$this->update();
+			$this->update($source !== null ? $source->getEntries() : []);
 		}
 	}
 
@@ -103,7 +109,7 @@ class Leaderboard implements \JsonSerializable{
 	}
 
 	public function isCustomDataType() : bool{
-		return !in_array($this->model->getCompoundTag()->getString(self::TAG_TYPE), DataType::ALL, true);
+		return !in_array($this->getType(), DataType::ALL, true);
 	}
 
 	public function update(array $data = []) : void{
@@ -118,7 +124,7 @@ class Leaderboard implements \JsonSerializable{
 		$this->updateText(Utils::getTopStatsText($data, $this->model, $this->text, self::TYPE_TEXT, $this->forceSorting));
 		$this->updateTitle(Utils::getTopStatsText($data, $this->model, $this->title, self::TYPE_TITLE, $this->forceSorting));
 		if($this->model instanceof NonPlayerCharacter){
-			$skin = Utils::getTopStatsPlayerSkin($data, $this->model->getCompoundTag()->getString(self::TAG_TYPE), $this->model->getCompoundTag()->getByte(self::TAG_TOP));
+			$skin = Utils::getTopStatsPlayerSkin($data, $this->getType(), $this->model->getCompoundTag()->getByte(self::TAG_TOP));
 			$this->model->setSkin($skin);
 		}
 	}

--- a/src/leaderboard/manager.php
+++ b/src/leaderboard/manager.php
@@ -27,6 +27,7 @@ namespace Nicholass003\TopStats\Leaderboard;
 use Exception;
 use Nicholass003\Textify\Lib\TextifyFactory;
 use Nicholass003\TopStats\Event\TopStatsUpdateEvent;
+use Nicholass003\TopStats\External\ExternalIntegrationRegistry;
 use Nicholass003\TopStats\TopStats;
 use pocketmine\utils\Config;
 use function array_filter;
@@ -35,7 +36,6 @@ use function is_array;
 use function json_decode;
 use function json_encode;
 use function substr;
-use const JSON_PRETTY_PRINT;
 
 class LeaderboardManager{
 
@@ -79,7 +79,7 @@ class LeaderboardManager{
 	public function getLeaderboardFromType(string $type) : array{
 		return array_filter(
 			$this->leaderboards,
-			fn($leaderboard) => $leaderboard->getModel()->getCompoundTag()->getString("TopStatsType") === $type
+			fn($leaderboard) => $leaderboard->getType() === $type
 		);
 	}
 
@@ -130,7 +130,8 @@ class LeaderboardManager{
 
 			$leaderboard = new Leaderboard($model);
 			if($leaderboard->getModel()->getModelPosition()->getWorld()->isLoaded()){
-				$leaderboard->update();
+				$source = ExternalIntegrationRegistry::getInstance()->getSource($leaderboard->getType());
+				$leaderboard->update($source !== null ? $source->getEntries() : []);
 			}
 
 			$this->leaderboards[$id] = $leaderboard;

--- a/src/plugin.php
+++ b/src/plugin.php
@@ -36,6 +36,8 @@ use Nicholass003\TopStats\Database\JsonDatabase;
 use Nicholass003\TopStats\Database\MySQLDatabase;
 use Nicholass003\TopStats\Database\SQLInterface;
 use Nicholass003\TopStats\Database\SQLiteDatabase;
+use Nicholass003\TopStats\External\ExternalIntegrationRegistry;
+use Nicholass003\TopStats\External\Support\TopVoterIntegration;
 use Nicholass003\TopStats\Leaderboard\LeaderboardManager;
 use Nicholass003\TopStats\Listener\EventListener;
 use Nicholass003\TopStats\Task\UpdateTask;
@@ -223,6 +225,7 @@ class TopStats extends PluginBase{
 			$this->economyProvider = libPiggyEconomy::getProvider($this->getConfig()->get("economy"));
 		}
 		$this->database->loadData();
+		$this->registerExternalIntegrations();
 		$this->leaderboardManager->loadData();
 		$this->registerTasks();
 	}
@@ -244,6 +247,28 @@ class TopStats extends PluginBase{
 	private function registerCommands() : void{
 		$commandMap = $this->getServer()->getCommandMap();
 		$commandMap->register("topstats", new TopStatsCommand($this, "topstats", "TopStats Command"));
+	}
+
+	private function registerExternalIntegrations() : void{
+		$pluginManager = $this->getServer()->getPluginManager();
+		$configIntegrations = $this->getConfig()->get("external-integrations", []);
+		$registry = ExternalIntegrationRegistry::getInstance();
+
+		$availableIntegrations = [
+			"TopVoter" => TopVoterIntegration::class,
+		];
+
+		foreach($configIntegrations as $pluginName => $isActive){
+			if(!$isActive || !$pluginManager->getPlugin($pluginName)){
+				continue;
+			}
+
+			if(!isset($availableIntegrations[$pluginName])){
+				continue;
+			}
+
+			$registry->register(new $availableIntegrations[$pluginName]());
+		}
 	}
 
 	private function registerListeners() : void{

--- a/src/utils/util.php
+++ b/src/utils/util.php
@@ -87,10 +87,13 @@ class Utils{
 		return $result;
 	}
 
-	public static function getTopStatsPlayerSkin(array $data, string $type, int $top) : Skin{
+	public static function getTopStatsPlayerSkin(array $data, string $type, int $top, bool $forceSorting = false) : Skin{
 		$playerName = "";
 		$num = 1;
-		foreach(self::getSortedArrayBoard($data, $type) as $xuid => $userData){
+		if(!$forceSorting){
+			$data = self::getSortedArrayBoard($data, $type);
+		}
+		foreach($data as $xuid => $userData){
 			if($num === $top){
 				$playerName = $userData["name"];
 				break;


### PR DESCRIPTION
# **Add External Integration System**

This PR introduces new APIs and structures enabling external plugin data to be integrated into TopStats, resolving https://github.com/nicholass003/TopStats/issues/12.

---

## **🔧 New APIs / Structures Added**

### **1. `ExternalIntegration` Interface**

Defines the contract for external stat providers:

* `getType() : string`
* `getEventClass() : string`
* `extractData(object $event) : array`
* `isForceSorting() : bool`

---

### **2. `ExternalSource`**

Data holder for each external type:

* stores type identifier
* stores integration instance
* stores extracted entries

---

### **3. `ExternalIntegrationRegistry`**

New registry responsible for:

* registering integrations
* mapping type → integration
* mapping type → ExternalSource
* registering event listeners for each integration
* handling event → data extraction
* dispatching leaderboard updates

New public API methods:

* `register(ExternalIntegration $integration, int $priority = NORMAL)`
* `unregister(string $type)`
* `getSource(string $type) : ?ExternalSource`
* `getActiveTypes() : array`

---

### **4. Dynamic Integration Loader**

`TopStats::registerExternalIntegrations()` now loads integrations based on config:

```
external-integrations:
  TopVoter: true
```

Only loads if the plugin is installed **and** enabled in config.

---

### **5. Added `TopVoterIntegration`**

First external integration implementation for SalmonDE’s TopVoter plugin.

---
